### PR TITLE
fix parameter name

### DIFF
--- a/classifier/optimisation/tune_hyperparameter_svm.m
+++ b/classifier/optimisation/tune_hyperparameter_svm.m
@@ -63,7 +63,7 @@ end
 acc = acc / N;
 
 % Best overall parameter
-[~, best_idx] = max(acc);
+[~, best_c_idx] = max(acc);
 
 % Diagnostic plots if requested
 if cfg.plot
@@ -73,7 +73,7 @@ if cfg.plot
     semilogx(cfg.c, acc)
     title([num2str(cfg.k) '-fold cross-validation performance'])
     hold all
-    plot([cfg.c(best_idx), cfg.c(best_idx)],ylim,'r--'),plot(cfg.c(best_idx), acc(best_idx),'ro')
+    plot([cfg.c(best_c_idx), cfg.c(best_c_idx)],ylim,'r--'),plot(cfg.c(best_c_idx), acc(best_c_idx),'ro')
     xlabel('Lambda'),ylabel('Accuracy'),grid on
 
 end


### PR DESCRIPTION
Dear Matthias, I was checking out your MVPA toolbox via the FieldTrip ft_timelockstatistics function. I think it is a great addition to FT especially in combination with the tutorial your made! I encountered what I believe is just a minor bug in the variable names in the svm classifier (see pull request).
Do you think it would be worth converting some of the classifiers from the previous DML toolbox to your code structure? 

Best,
Sophie