### PR TITLE
Fix cf field name in test_libsvm

### DIFF
--- a/classifier/test_libsvm.m
+++ b/classifier/test_libsvm.m
@@ -12,13 +12,13 @@ function [clabel,dval] = test_libsvm(cf,X)
 % clabel        - predicted class labels
 % dval          - decision values
 
-[clabel, ~, dval] = svmpredict(zeros(size(X,1),1), X, cf,'-q');
+[clabel, ~, dval] = svmpredict(zeros(size(X,1),1), X, cf.model,'-q');
 
 % Note that dvals might be sign-reversed in some cases,
 % see http://www.csie.ntu.edu.tw/~cjlin/libsvm/faq.html#f430
 % To fix this behavior, we inspect cf.Labels: Label(1) denotes the positive 
 % class (should be 1)
-if cf.Label(1) ~= 1
+if cf.model.Label(1) ~= 1
     % 1 is negative class, hence we need to flip dvals
     dval = -dval;
 end


### PR DESCRIPTION
Hi Matthias,

thanks for the awesome toolbox, I'm really enjoying it so far! I've been playing around with it a bit, and I think I found a small bug: If I use the libsvm classifier, e.g.

`cfg = [];
cfg.classifier = 'libsvm';
cfg.repeat = 2;
out = mv_classify_across_time(cfg, dat, labels)`

I get 'Reference to non-existent field 'Label'.'. This happens because [train_libsvm stores the trained model in cf.model](https://github.com/treder/MVPA-Light/blob/25253ed25a497206e6159d09a61c0a0cc8e4b72b/classifier/train_libsvm.m#L72) and [test_svm looks for it](https://github.com/treder/MVPA-Light/blob/25253ed25a497206e6159d09a61c0a0cc8e4b72b/classifier/test_libsvm.m#L15) in [cf directly.](https://github.com/treder/MVPA-Light/blob/25253ed25a497206e6159d09a61c0a0cc8e4b72b/classifier/test_libsvm.m#L21)

Changing both references to cf.model seems to fix it.

Best, 

Ben
