### PR TITLE
ENH - hack to improve speed when doing double searchlight with naive_…

### DIFF
--- a/model/test_naive_bayes.m
+++ b/model/test_naive_bayes.m
@@ -1,4 +1,4 @@
-function [clabel, dval, prob] = test_naive_bayes(cf,X)
+function [clabel, dval, prob, dval_univariate] = test_naive_bayes(cf,X)
 % Applies a Naive Bayes classifier to test data.
 %
 % Usage:
@@ -18,25 +18,37 @@ function [clabel, dval, prob] = test_naive_bayes(cf,X)
 % dval and prob comes as matrices and hence should not be used
 % within the high-level functions. They can be used when test_naive_bayes
 % is called by hand.
-dval = arrayfun( @(c) -( bsxfun(@minus, X, cf.class_means(c,:)) .^2) ./ repmat(cf.var(c,:), [size(X,1) ,1]), 1:cf.nclasses, 'Un',0);
-dval = cell2mat( cellfun(@(d) sum(d,2)/2, dval, 'Un',0));
+if iscell(X) && isfield(cf, 'ix_nb')
+  dval = zeros(size(X{1},1), numel(X));
+  for k = 1:numel(X)
+    tmp = X{k}(:,cf.ix_nb{:});
+    dval(:,k) = sum(tmp(:,:),2)/2;    
+  end
+else
+  dval = arrayfun( @(c) -( bsxfun(@minus, X, cf.class_means(c,:,:)) .^2) ./ cf.var(c*ones(size(X,1),1),:,:), 1:cf.nclasses, 'Un',0);
+  if nargout>3
+    dval_univariate = dval;
+  end
+  dval = cell2mat( cellfun(@(d) sum(d,2)/2, dval, 'Un',0));
+end
 
 % add prior
 dval = bsxfun(@plus, dval, cf.prior);
 
 % For each sample, find the closest centroid and assign it to the
 % respective class
-clabel = zeros(size(X,1),1);
-for ii=1:size(X,1)
-    [~, clabel(ii)] = max(dval(ii,:));
-end
+[~, clabel] = max(dval, [], 2); % this avoids an expensive for-loop
+% clabel = zeros(size(X,1),1);
+% for ii=1:size(X,1)
+%     [~, clabel(ii)] = max(dval(ii,:));
+% end
 
 if nargout>2
     % apply softmax to obtain the posterior probabilities
     prob = exp(dval);
     Px = sum(prob,2);
     for cc=1:cf.nclasses
-        prob(:,cc) = prob(:,cc) ./ Px;
+        prob(:,cc,:) = prob(:,cc,:) ./ Px;
     end
 end
 

--- a/model/train_naive_bayes.m
+++ b/model/train_naive_bayes.m
@@ -27,19 +27,28 @@ function cf = train_naive_bayes(param, X, clabel)
 
 % (c) Matthias Treder
 
-nclasses = max(clabel);
-nfeatures = size(X,2);
-
-% Indices of class samples
-ix = arrayfun(@(c) find(clabel == c), 1:nclasses, 'Un', 0);
-
-%% Estimate class-conditional means and standard deviations
-class_means = zeros(nclasses, nfeatures);
-va = zeros(nclasses, nfeatures);
-
-for cc=1:nclasses
-    class_means(cc,:) = mean(X(ix{cc}, :), 1);
-    va(cc,:) = var(X(ix{cc}, :), [], 1);
+if ~isfield(param, 'class_means') || isempty(param.class_means)
+  
+  nclasses = max(clabel);
+  nfeatures = size(X);
+  nfeatures = nfeatures(2:end);
+  
+  % Indices of class samples
+  ix = arrayfun(@(c) find(clabel == c), 1:nclasses, 'Un', 0);
+  
+  %% Estimate class-conditional means and standard deviations
+  class_means = zeros([nclasses, nfeatures]);
+  va = zeros([nclasses, nfeatures]);
+  
+  for cc=1:nclasses
+    class_means(cc,:,:) = mean(X(ix{cc}, :, :), 1);
+    va(cc,:,:) = var(X(ix{cc}, :, :), [], 1);
+  end
+else
+  
+  class_means = param.class_means(:, param.ix_nb{:});
+  va          = param.var(:, param.ix_nb{:});
+  nclasses    = param.nclasses;
 end
 
 %% Set up classifier struct
@@ -47,6 +56,9 @@ cf              = [];
 cf.class_means  = class_means;
 cf.var          = va;
 cf.nclasses     = nclasses;
+if isfield(param, 'ix_nb')
+  cf.ix_nb = param.ix_nb;
+end
 
 if ischar(param.prior)
     cf.prior        = log(ones(1,nclasses)/nclasses);

--- a/mv_classify.m
+++ b/mv_classify.m
@@ -309,7 +309,7 @@ if ~strcmp(cfg.cv,'none')
               cf = train_fun(cfg.hyperparameter, Xtrain, trainlabel);             
               cfg.hyperparameter.class_means = cf.class_means;
               cfg.hyperparameter.var         = cf.var;
-              cfg.hyperparameter.nclasses    = 4;
+              cfg.hyperparameter.nclasses    = cf.nclasses;
               
               [~, ~, ~, dval_univariate] = test_fun(cf, Xtest);
               


### PR DESCRIPTION
…bayes

OK, this is a bit of Spielerei really to see whether I understand the mvpa code etc. So currently no intention to get this merged, just creating a PR to put it on @treder 's radar. Feel free to ignore.

I noticed that playing with a dataset that a double searchlight becomes extremely slow due to code design issues.

specifically, using naive_bayes, and a 4 class problem, + spatial searchlight + temporal searchlight the marginal means and variances are the double for-loop (which results in a lot of redundant computations.

My hacks here lead to a substantial speed up of the computations (10-fold or so), but they might go against @treder grand philosophy of the code.