### PR TITLE
update libsvm train and test function to properly work in multiclass classifications

### DIFF
--- a/model/test_libsvm.m
+++ b/model/test_libsvm.m
@@ -25,7 +25,7 @@ end
 if cf.svm_type < 3
     % CLASSIFICATION
     % clabel come as 0 and 1, need to translate back to 1 and 2
-    ypred(ypred==0) = 2;
+    ypred = ypred + 1;
     
     % Note that dvals might be sign-reversed in some cases,
     % see http://www.csie.ntu.edu.tw/~cjlin/libsvm/faq.html#f430

--- a/model/train_libsvm.m
+++ b/model/train_libsvm.m
@@ -92,7 +92,7 @@ end
 cf = [];
 
 if param.svm_type < 3
-    y = double(y(:)==1);         % classification
+    y = double(y - 1);         % classification
 else
     y = double(y(:));            % regression
 end


### PR DESCRIPTION
In multiclass problems, train_libsvm transform labels to 0, 1 and mistakenly change it to two-class classifications. Also, test_libsvm considers predicted labels as 0 and 1, which is incorrect in a multiclass classification problem.