### PR TITLE
ENH - broadcast the testdesign to the outside world

### DIFF
--- a/mv_regress.m
+++ b/mv_regress.m
@@ -30,6 +30,10 @@ function [perf, result] = mv_regress(cfg, X, Y, varargin)
 %                   sample is returned. Use cell array to specify multiple 
 %                   metrics (eg {'mae' 'mse'}).
 % .feedback       - print feedback on the console (default 1)
+% .save           - use to save train responses or model parameters for each train iteration.
+%                   The cell array can contain  'y_train', 'model_param' 
+%                   (ie classifier parameters) (default {}). 
+%                   The results struct then contains the eponymous fields.
 %
 % For mv_regress to make sense of the data, the user must specify the
 % meaning of each dimension. sample_dimension and feature_dimension
@@ -116,6 +120,7 @@ mv_set_default(cfg,'hyperparameter',[]);
 mv_set_default(cfg,'metric','mean_absolute_error');
 mv_set_default(cfg,'add_intercept',1);
 mv_set_default(cfg,'feedback',1);
+mv_set_default(cfg,'save',{});
 
 mv_set_default(cfg,'sample_dimension',1);
 mv_set_default(cfg,'feature_dimension',2);
@@ -274,6 +279,11 @@ nfeat = [size(X) ones(1, numel(cfg.dimension_names) - ndims(X))];
 nfeat = nfeat(feature_dim);
 if isempty(nfeat), nfeat = 1; end
 
+%% prepare save
+if ~iscell(cfg.save), cfg.save = {cfg.save}; end
+save_model = any(strcmp(cfg.save, 'model_param'));
+save_y_train = any(strcmp(cfg.save, 'y_train'));
+
 %% Perform regression
 if ~strcmp(cfg.cv,'none') && ~has_second_dataset
     % -------------------------------------------------------
@@ -282,6 +292,8 @@ if ~strcmp(cfg.cv,'none') && ~has_second_dataset
     % Initialize regression model outputs
     model_output = cell([cfg.repeat, cfg.k, sz_search]);
     y_test = cell([cfg.repeat, cfg.k]);
+    if save_y_train, all_y_train = cell([cfg.repeat, cfg.k]); end
+    if save_model, all_model = cell(size(model_output)); end
     
     for rr=1:cfg.repeat                 % ---- CV repetitions ----
         if cfg.feedback, fprintf('Repetition #%d. Fold ',rr), end
@@ -324,7 +336,8 @@ if ~strcmp(cfg.cv,'none') && ~has_second_dataset
                 new_sz_search = size(X_test);
                 X_test = reshape(X_test, [new_sz_search(1)*new_sz_search(2), new_sz_search(3:end)]);
             end
-            
+            if save_y_train, all_y_train{rr,kk} = y_train; end
+
             % Remember sizes
             sz_Xtrain = size(X_train);
             sz_Xtest = size(X_test);
@@ -364,6 +377,8 @@ if ~strcmp(cfg.cv,'none') && ~has_second_dataset
                     % multivariate output
                     model_output{rr,kk,ix{:}} = reshape( test_fun(model, X_test_ix), size(y_test{rr,kk},1),size(y_test{rr,kk},2),[]);
                 end
+                if save_model, all_model{rr,kk,ix{:}} = model; end
+
             end
 
         end
@@ -380,7 +395,8 @@ elseif has_second_dataset
     
     % Initialize classifier outputs
     model_output = cell([1, 1, sz_search]);
-    
+    if save_model, all_model = cell(size(model_output)); end
+
     % Preprocess train data
     [tmp_cfg, X, Y] = mv_preprocess(cfg, X, Y);
     
@@ -433,8 +449,10 @@ elseif has_second_dataset
             % multivariate output
             model_output{1,1,ix{:}} = reshape( test_fun(model, X_test_ix), size(Y2,1),size(Y2,2),[]);
         end
+        if save_model, all_model{ix{:}} = model; end
     end
     
+    all_y_train = Y;
     y_test = Y2;
     avdim = [];
     
@@ -452,7 +470,8 @@ elseif strcmp(cfg.cv,'none')
     
     % Initialise regression model outputs
     model_output = cell([1, 1, sz_search]);
-    
+    if save_model, all_model = cell(size(model_output)); end
+
     if ~isempty(gen_dim)
         X_test= permute(X, [sample_dim, search_dim(end), search_dim(1:end-1), feature_dim]);
         
@@ -502,9 +521,11 @@ elseif strcmp(cfg.cv,'none')
             % multivariate output
             model_output{1,1,ix{:}} = reshape( test_fun(model, X_test_ix), size(Y,1),size(Y,2),[]);
         end
-        
+        if save_model, all_model{ix{:}} = model; end
+
     end
 
+    all_y_train = Y;
     y_test = Y;
     avdim = [];
 end
@@ -545,10 +566,12 @@ if nargout>1
    result.perf                  = perf;
    result.perf_std              = perf_std;
    result.perf_dimension_names  = perf_dimension_names;
-   result.testdesign            = y_test;
+   result.y_test                = y_test;
    result.n                     = size(X, 1);
    result.n_metrics             = n_metrics;
    result.metric                = cfg.metric;
    result.model                 = cfg.model;
    result.cfg                   = cfg;
+   if save_y_train, result.y_train = all_y_train; end
+   if save_model, result.model_param = all_model; end
 end

--- a/mv_regress.m
+++ b/mv_regress.m
@@ -545,6 +545,7 @@ if nargout>1
    result.perf                  = perf;
    result.perf_std              = perf_std;
    result.perf_dimension_names  = perf_dimension_names;
+   result.testdesign            = y_test;
    result.n                     = size(X, 1);
    result.n_metrics             = n_metrics;
    result.metric                = cfg.metric;

--- a/unittests/unittest_mv_classify.m
+++ b/unittests/unittest_mv_classify.m
@@ -505,7 +505,7 @@ perf   = mv_classify(cfg, X, clabel, X2, clabel2);
 
 print_unittest_result('transfer classification with generalization', [size(X,3) size(X2,3)], size(perf), tol);
 
-%% misc: if a field result.misc should be present with 
+%% save: test for fields 'trainlabel' and 'model_param'
 nsamples = 20;
 nfeatures = 12;
 ntime = 100;
@@ -517,17 +517,28 @@ cfg = [];
 cfg.repeat = 2;
 cfg.k = 5;
 cfg.feedback = 0;
+cfg.save = {};
 [~, result] = mv_classify(cfg, X, clabel);
 
-print_unittest_result('[misc=0] no misc.result present', true, ~isfield(result,'misc'), tol);
+print_unittest_result('[save={}] no trainlabel or model_param in result', true, (~isfield(result,'trainlabel'))&&(~isfield(result,'model_param')), tol);
 
-cfg.misc = 1;
+cfg.save = {'trainlabel'};
 [~, result] = mv_classify(cfg, X, clabel);
-print_unittest_result('[misc=1] misc.result present', true, isfield(result,'misc'), tol);
-print_unittest_result('[misc=1] misc.result with subfields of right size', true, ...
-    isfield(result,'misc') && all(size(result.misc.trainlabel) == [cfg.repeat, cfg.k]) && all(size(result.misc.testlabel) == [cfg.repeat, cfg.k]) && all(size(result.misc.model) == [cfg.repeat, cfg.k]) , tol);
+print_unittest_result('[save=trainlabel] trainlabel present', true, isfield(result,'trainlabel'), tol);
+print_unittest_result('[save=trainlabel] model_param not present', false, isfield(result,'model_param'), tol);
 
-% add time dimension: now result.misc.model should have an extra dimension
+cfg.save = {'trainlabel' 'model_param'};
+[~, result] = mv_classify(cfg, X, clabel);
+print_unittest_result('[save=trainlabel,model_param] trainlabel and model_param', true, isfield(result,'trainlabel')&&isfield(result,'model_param'), tol);
+
+% add time dimension: now result.misc.model_param should have an extra dimension
 X = randn(nsamples, nfeatures, ntime);
+cfg.save = 'model_param';
 [~, result] = mv_classify(cfg, X, clabel);
-print_unittest_result('[misc=1] misc.result.model for 3D data', [cfg.repeat, cfg.k, ntime], size(result.misc.model), tol);
+print_unittest_result('[save=model_param] misc.result.model_param for 3D data', [cfg.repeat, cfg.k, ntime], size(result.model_param), tol);
+
+% no cross val
+cfg.save = {'model_param' 'trainlabel'};
+cfg.cv = 'none';
+[~, result] = mv_classify(cfg, X, clabel);
+print_unittest_result('[save=model_param, trainlabel, no crossval] misc.result.model_param', [1, 1, ntime], size(result.model_param), tol);

--- a/unittests/unittest_mv_classify.m
+++ b/unittests/unittest_mv_classify.m
@@ -504,3 +504,30 @@ cfg.feedback = 0;
 perf   = mv_classify(cfg, X, clabel, X2, clabel2);
 
 print_unittest_result('transfer classification with generalization', [size(X,3) size(X2,3)], size(perf), tol);
+
+%% misc: if a field result.misc should be present with 
+nsamples = 20;
+nfeatures = 12;
+ntime = 100;
+X = randn(nsamples, nfeatures);
+clabel = ones(nsamples,1);
+clabel(1:2:end) = 2;
+
+cfg = [];
+cfg.repeat = 2;
+cfg.k = 5;
+cfg.feedback = 0;
+[~, result] = mv_classify(cfg, X, clabel);
+
+print_unittest_result('[misc=0] no misc.result present', true, ~isfield(result,'misc'), tol);
+
+cfg.misc = 1;
+[~, result] = mv_classify(cfg, X, clabel);
+print_unittest_result('[misc=1] misc.result present', true, isfield(result,'misc'), tol);
+print_unittest_result('[misc=1] misc.result with subfields of right size', true, ...
+    isfield(result,'misc') && all(size(result.misc.trainlabel) == [cfg.repeat, cfg.k]) && all(size(result.misc.testlabel) == [cfg.repeat, cfg.k]) && all(size(result.misc.model) == [cfg.repeat, cfg.k]) , tol);
+
+% add time dimension: now result.misc.model should have an extra dimension
+X = randn(nsamples, nfeatures, ntime);
+[~, result] = mv_classify(cfg, X, clabel);
+print_unittest_result('[misc=1] misc.result.model for 3D data', [cfg.repeat, cfg.k, ntime], size(result.misc.model), tol);

--- a/unittests/unittest_mv_classify_across_time.m
+++ b/unittests/unittest_mv_classify_across_time.m
@@ -199,3 +199,41 @@ perf_2 = mv_classify_across_time(cfg, X, clabel, X2_2, clabel2_2);
 print_unittest_result('transfer classification: testing both classes vs only class 1', perf(:,1), perf_1(:,1), tol);
 print_unittest_result('transfer classification: testing both classes vs only class 2', perf(:,2), perf_2(:,2), tol);
 
+%% save: test for fields 'trainlabel' and 'model_param'
+nsamples = 20;
+nfeatures = 12;
+ntime = 100;
+X = randn(nsamples, nfeatures, ntime);
+clabel = ones(nsamples,1);
+clabel(1:2:end) = 2;
+
+cfg = [];
+cfg.repeat = 2;
+cfg.k = 5;
+cfg.feedback = 0;
+cfg.save = {};
+[~, result] = mv_classify_across_time(cfg, X, clabel);
+
+print_unittest_result('[save={}] no trainlabel or model_param in result', true, (~isfield(result,'trainlabel'))&&(~isfield(result,'model_param')), tol);
+
+cfg.save = {'trainlabel'};
+[~, result] = mv_classify_across_time(cfg, X, clabel);
+print_unittest_result('[save=trainlabel] trainlabel present', true, isfield(result,'trainlabel'), tol);
+print_unittest_result('[save=trainlabel] model_param not present', false, isfield(result,'model_param'), tol);
+
+cfg.save = {'trainlabel' 'model_param'};
+[~, result] = mv_classify_across_time(cfg, X, clabel);
+print_unittest_result('[save=trainlabel,model_param] trainlabel and model_param', true, isfield(result,'trainlabel')&&isfield(result,'model_param'), tol);
+
+% add time dimension: now result.misc.model_param should have an extra dimension
+X = randn(nsamples, nfeatures, ntime);
+cfg.save = 'model_param';
+[~, result] = mv_classify_across_time(cfg, X, clabel);
+print_unittest_result('[save=model_param] misc.result.model_param for 3D data', [cfg.repeat, cfg.k, ntime], size(result.model_param), tol);
+
+% no cross val
+cfg.save = {'model_param' 'trainlabel'};
+cfg.cv = 'none';
+[~, result] = mv_classify_across_time(cfg, X, clabel);
+print_unittest_result('[save=model_param, trainlabel, no crossval] misc.result.model_param', [1, 1, ntime], size(result.model_param), tol);
+

--- a/unittests/unittest_mv_classify_timextime.m
+++ b/unittests/unittest_mv_classify_timextime.m
@@ -176,3 +176,44 @@ for cv = {'kfold' ,'leaveout', 'holdout', 'none'}
     cfg.cv = cv{:};
     mv_classify_timextime(cfg, X, clabel);
 end
+
+
+
+%% save: test for fields 'trainlabel' and 'model_param'
+nsamples = 20;
+nfeatures = 12;
+ntime = 100;
+X = randn(nsamples, nfeatures, ntime);
+clabel = ones(nsamples,1);
+clabel(1:2:end) = 2;
+
+cfg = [];
+cfg.repeat = 2;
+cfg.k = 5;
+cfg.feedback = 0;
+cfg.save = {};
+[~, result] = mv_classify_timextime(cfg, X, clabel);
+
+print_unittest_result('[save={}] no trainlabel or model_param in result', true, (~isfield(result,'trainlabel'))&&(~isfield(result,'model_param')), tol);
+
+cfg.save = {'trainlabel'};
+[~, result] = mv_classify_timextime(cfg, X, clabel);
+print_unittest_result('[save=trainlabel] trainlabel present', true, isfield(result,'trainlabel'), tol);
+print_unittest_result('[save=trainlabel] model_param not present', false, isfield(result,'model_param'), tol);
+
+cfg.save = {'trainlabel' 'model_param'};
+[~, result] = mv_classify_timextime(cfg, X, clabel);
+print_unittest_result('[save=trainlabel,model_param] trainlabel and model_param', true, isfield(result,'trainlabel')&&isfield(result,'model_param'), tol);
+
+% add time dimension: now result.misc.model_param should have an extra dimension
+X = randn(nsamples, nfeatures, ntime);
+cfg.save = 'model_param';
+[~, result] = mv_classify_timextime(cfg, X, clabel);
+print_unittest_result('[save=model_param] misc.result.model_param for 3D data', [cfg.repeat, cfg.k, ntime], size(result.model_param), tol);
+
+% no cross val
+cfg.save = {'model_param' 'trainlabel'};
+cfg.cv = 'none';
+[~, result] = mv_classify_timextime(cfg, X, clabel);
+print_unittest_result('[save=model_param, trainlabel, no crossval] misc.result.model_param', [1, 1, ntime], size(result.model_param), tol);
+

--- a/unittests/unittest_mv_regress.m
+++ b/unittests/unittest_mv_regress.m
@@ -312,3 +312,43 @@ cfg.feedback = 0;
 perf   = mv_regress(cfg, x, y, x2, y2);
 
 print_unittest_result('transfer regression with generalization', [size(x,3) size(x2,3)], size(perf), tol);
+
+
+
+%% save: test for fields 'y_train' and 'model_param'
+nsamples = 20;
+nfeatures = 12;
+ntime = 100;
+X = zeros(nsamples, nfeatures, ntime);
+[x, y] = simulate_regression_data('linear', nsamples, nfeatures, 0);
+
+cfg = [];
+cfg.repeat = 2;
+cfg.k = 5;
+cfg.feedback = 0;
+cfg.save = {};
+[~, result] = mv_regress(cfg, X, clabel);
+
+print_unittest_result('[save={}] no y_train or model_param in result', true, (~isfield(result,'y_train'))&&(~isfield(result,'model_param')), tol);
+
+cfg.save = {'y_train'};
+[~, result] = mv_regress(cfg, X, clabel);
+print_unittest_result('[save=y_train] y_train present', true, isfield(result,'y_train'), tol);
+print_unittest_result('[save=y_train] model_param not present', false, isfield(result,'model_param'), tol);
+
+cfg.save = {'y_train' 'model_param'};
+[~, result] = mv_regress(cfg, X, clabel);
+print_unittest_result('[save=y_train,model_param] y_train and model_param', true, isfield(result,'y_train')&&isfield(result,'model_param'), tol);
+
+% add time dimension: now result.misc.model_param should have an extra dimension
+X = randn(nsamples, nfeatures, ntime);
+cfg.save = 'model_param';
+[~, result] = mv_regress(cfg, X, clabel);
+print_unittest_result('[save=model_param] misc.result.model_param for 3D data', [cfg.repeat, cfg.k, ntime], size(result.model_param), tol);
+
+% no cross val
+cfg.save = {'model_param' 'y_train'};
+cfg.cv = 'none';
+[~, result] = mv_regress(cfg, X, clabel);
+print_unittest_result('[save=model_param, y_train, no crossval] misc.result.model_param', [1, 1, ntime], size(result.model_param), tol);
+

--- a/utils/mv_check_inputs.m
+++ b/utils/mv_check_inputs.m
@@ -40,7 +40,6 @@ end
 %% clabel and cfg: check whether there's more than 2 classes but yet a binary classifier is used
 binary_classifiers = {'lda' 'logreg' 'svm'};
 if n_classes > 2 && ismember(cfg.classifier, binary_classifiers)
-perf      = mv_regress(cfg, x, y, x, y);
     error('Cannot use %s for a classification task with %d classes: use a multiclass classifier instead (see https://github.com/treder/MVPA-Light/ for a list of classifiers)', upper(cfg.classifier), n_classes)
 end
 


### PR DESCRIPTION
second try: I was wondering whether there's a reason not to broadcast the (CV-)test design to the result output structure. If not, this PR adds it.

as an added note to @treder: is there a specific reason why the high level mv_classify/mv_regress function do not output the classification/regression weights (optionally)? I can imagine that this might easily blow up in terms of memory consumption, but I have now worked with a few researchers who are actually interested in evaluating those (e.g. looking at topographies), or use them in a more advanced cross-decoding context.