### PR TITLE
Other models

### DIFF
--- a/preprocess/mv_preprocess_pca.m
+++ b/preprocess/mv_preprocess_pca.m
@@ -16,7 +16,9 @@ function [pparam, X, clabel] = mv_preprocess_pca(pparam, X, clabel)
 % .feature_dimension - which dimension codes the features (eg the channels)
 %                     (default 2)
 % .normalize        - if 1, all PCs are scaled to have variance 1 (default
-%                     1). This only works if X has a rank of at least n. 
+%                     1). This only works if X has a rank of at least n.
+% .omitrows         - if 1, rows with nans are omitted from the covariance
+%                     computation (default 0)
 %
 % Note: features x features covariance matrices are calculated across the
 % target dimension. A covariance matrix is calculated for every element of
@@ -70,11 +72,19 @@ if pparam.is_train_set
     % to flip the matrix for the covariance calculation
     if f < t
         for ix = dim_loop
+          if pparam.omitrows
+            C = C + cov(squeeze(X(ix{:},:))', 'omitrows');
+          else
             C = C + cov(squeeze(X(ix{:},:))');
+          end
         end
     else
         for ix = dim_loop
+          if pparam.omitrows
+            C = C + cov(squeeze(X(ix{:},:)), 'omitrows');
+          else
             C = C + cov(squeeze(X(ix{:},:)) );
+          end
         end
     end
     

--- a/preprocess/mv_preprocess_zscore.m
+++ b/preprocess/mv_preprocess_zscore.m
@@ -15,6 +15,8 @@ function [pparam, X, clabel] = mv_preprocess_zscore(pparam, X, clabel)
 % .dimension        - which dimension(s) of the data matrix will be used
 %                     for z-scoring. Typically the dimension representing
 %                     the samples (default 1)
+% .omitnan          - boolean flag to omit nans or not (default 0). If the
+%                     data contains nans, it makes sense to use 1
 %
 % Nested preprocessing: For train data, preprocess_param.mean and 
 % preprocess_param.standard_deviation are calculated
@@ -22,8 +24,13 @@ function [pparam, X, clabel] = mv_preprocess_zscore(pparam, X, clabel)
 % obtained from the train data are used to scale the test data.
 
 if pparam.is_train_set
+  if pparam.omitnan
+    pparam.mean = mean(X, pparam.dimension, 'omitnan');
+    pparam.standard_deviation = std(X, [], pparam.dimension, 'omitnan');    
+  else
     pparam.mean = mean(X, pparam.dimension);
     pparam.standard_deviation = std(X, [], pparam.dimension);    
+  end
 end
 
 % Remove mean from data and divide by standard deviation

--- a/utils/mv_calculate_performance.m
+++ b/utils/mv_calculate_performance.m
@@ -279,7 +279,7 @@ switch(metric)
         % https://en.wikipedia.org/wiki/Student%27s_t-test#Equal_or_unequal_sample_sizes.2C_equal_variance
         perf = cell(sz_output);
         
-         % Aggregate across samples, for each class separately
+        % Aggregate across samples, for each class separately
         if nextra == 1
             % Get means
             M1 = cellfun( @(cfo,lab) nanmean(cfo(lab==1,:,:,:,:,:,:,:,:,:),1), model_output, y, 'Un',0);

--- a/utils/mv_check_inputs.m
+++ b/utils/mv_check_inputs.m
@@ -22,13 +22,15 @@ if n_classes==1
 end
 
 if iscell(clabel) || ~all(ismember(clabel,1:n_classes))
-    warning('clabel should be a vector consisting of integers 1 (class 1), 2 (class 2), 3 (class 3) and so on. Relabelling them accordingly.');
+    clabelorig = clabel;
+    warning('clabel should almost always be a vector consisting of integers 1 (class 1), 2 (class 2), 3 (class 3) and so on. Relabelling them accordingly.');
     newlabel = nan(numel(clabel), 1);
     for i = 1:n_classes
         newlabel(ismember(clabel, u(i))) = i; % set to 1:nth classes
     end
     clabel = newlabel;
     if has_second_dataset
+        clabel2orig = clabel2;
         newlabel = nan(numel(clabel2), 1);
         for i = 1:n_classes
             newlabel(ismember(clabel2, u(i))) = i;
@@ -270,3 +272,10 @@ end
 
 %% cfg: set defaults for classifier hyperparameter
 cfg.hyperparameter = mv_get_hyperparameter(cfg.classifier, cfg.hyperparameter);
+if isfield(cfg.hyperparameter, 'relabel_design') && ~cfg.hyperparameter.relabel_design
+    warning('overruling the relabelling of the design, switching back to the original');
+    clabel = clabelorig;
+    if has_second_dataset
+      clabel2 = clabel2orig;
+    end
+end

--- a/utils/mv_get_hyperparameter.m
+++ b/utils/mv_get_hyperparameter.m
@@ -167,6 +167,23 @@ switch(model)
         mv_set_default(param,'lambda_y','auto');
         mv_set_default(param,'form', 'auto');
 
-
-    otherwise, error('Unknown model ''%s''',model)
+ 
+  otherwise
+        % check for the existence of a triplet of functions:
+        %   train_<model>
+        %   test_<model>
+        %   params_<model>
+        % if these conditions are met then it may be something that has
+        % been developed at home, let's give it a shot
+        if exist(sprintf('train_%s', model), 'file') == 2 && ...
+           exist(sprintf('test_%s', model), 'file') ==2 && ...
+           exist(sprintf('params_%s', model), 'file') == 2
+          try
+            param = feval(sprintf('params_%s', model), param);
+          catch
+            error('Failed to get default parameters for model %s', model);
+          end
+        else
+           error('Unknown model ''%s''',model)
+        end
 end

--- a/utils/mv_get_preprocess_param.m
+++ b/utils/mv_get_preprocess_param.m
@@ -87,6 +87,7 @@ switch(preprocess)
         mv_set_default(preprocess_param,'target_dimension',3);
         mv_set_default(preprocess_param,'normalize',1);
         mv_set_default(preprocess_param,'select_data',[]);
+        mv_set_default(preprocess_param,'omitrows',0);
     
     case 'impute_nan'
         mv_set_default(preprocess_param,'is_train_set',1);
@@ -119,4 +120,5 @@ switch(preprocess)
         mv_set_default(preprocess_param,'is_train_set',1);
         mv_set_default(preprocess_param,'dimension',1);     
         mv_set_default(preprocess_param,'select_data',[]);
+        mv_set_default(preprocess_param,'omitnan',0);
 end


### PR DESCRIPTION
this PR intends to allow custom written models to be used within  the data bookkeeping framework of MVPA-light.
it requires a custom triplet of functions: train_<modelname>.m, test_<modelname>.m and params_<modelname>.m